### PR TITLE
Update DistanceCalculator.py

### DIFF
--- a/DistanceCalculator.py
+++ b/DistanceCalculator.py
@@ -55,7 +55,7 @@ def createPath(costSurfaceArray,startCoord,stopCoord):
 def calculateDistance(pathIndices):
     distance = 0
     for i in range(0,(len(pathIndices[0])-1)):
-        distance += vincenty((pathIndices[1,i], pathIndices[0,i]), (pathIndices[1,i+1], pathIndices[0,i+1])).miles*0.868976
+        distance += vincenty((pathIndices[0,i], pathIndices[1,i]), (pathIndices[0,i+1], pathIndices[1,i+1])).miles*0.868976
     return distance
 
 
@@ -69,6 +69,6 @@ def distanceCalculator(startCoord, stopCoord):
 #Test, in this case it's from CATANIA to MANTA
 ports.Port[1000]
 startCoord = (ports.longitude[2205], ports.latitude[2205])
-stopCoord = (ports.longitude[1000], ports.latitude[100])
+stopCoord  = (ports.longitude[1000], ports.latitude[1000])
 
 distanceCalculator(startCoord, stopCoord)


### PR DESCRIPTION
When the function distanceCalculator calls the function createPath, it passes the coordinates in the format (longitude, latitude). But while creating the indices on path, the function route_through_array again takes the input in reversed format. Hence the returned indices are in the format (latitude_index, longitude_index) which is then converted to (latitudes,longitudes). And this is returned from createPath. So when distanceCalculator calls calculateDistance, it is actually passing the coordinates in (Latitude, Longitudes) order. Hence there is not need to reverse that order while calculating distance.

The edit in the test case is just to make the stopCoord latitude be fetched from the same port entry as its longitude. It was mistakenly written as ports.latitude[100] when it should have been ports.latitude[1000].